### PR TITLE
fix(android): remove leading zero from relative version code

### DIFF
--- a/src/version/android.ts
+++ b/src/version/android.ts
@@ -35,7 +35,8 @@ const getNextAndroidVersionCode = (
       return currentVersionCode;
     }
 
-    return semanticBuildNumber;
+    // For relative strategy, remove any leading zero, as it would be encoded as an octal number
+    return parseInt(semanticBuildNumber, 10).toString();
   }
 
   if (strategy?.buildNumber === 'relative-extended') {

--- a/src/version/utils.ts
+++ b/src/version/utils.ts
@@ -19,7 +19,7 @@ export const stripPrereleaseVersion = (version: string) => {
 /**
  * Get a build number that is relative to the semantic version.
  *
- * For example, v1.2.3 becomes 102030.
+ * For example, v1.2.3 becomes 010203.
  */
 export const getSemanticBuildNumber = (
   version: string,

--- a/tests/prepare.test.ts
+++ b/tests/prepare.test.ts
@@ -197,9 +197,9 @@ describe('prepare', () => {
 
     it.each`
       version       | expectedVersionCode
-      ${'1.0.0'}    | ${'010000'}
+      ${'1.0.0'}    | ${'10000'}
       ${'10.1.10'}  | ${'100110'}
-      ${'1.12.1'}   | ${'011201'}
+      ${'1.12.1'}   | ${'11201'}
       ${'99.99.99'} | ${'999999'}
     `(
       'updates the versionCode to $expectedVersionCode for version $version when using the relative strategy',


### PR DESCRIPTION
This is the solution I currently found for https://github.com/alexandermendes/semantic-release-react-native/issues/11

Works only for ´relative´. ´relative-extended´ will still pad the number, as it is not touched by the octal encoding issue.