### PR TITLE
feat: added env strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ This is similar to the `semantic` strategy described above, yet with the additio
 of the minumum API level as the first two digits, followed by a zero. It also
 faces the same downsides as the `semantic` strategy.
 
+#### `env`
+
+Read `versionCode` from environment variable `ANDROID_BUILD_NUMBER`.
+
 #### `none`
 
 Disable updates of the `versionCode`.
@@ -180,6 +184,10 @@ This strategy behaves the same as the `relative` strategy for Android.
 #### `semantic`
 
 Use the semantic version number directly.
+
+#### `env`
+
+Use the version from environment variable `IOS_BUILD_NUMBER`.
 
 #### `none`
 

--- a/src/strategies.ts
+++ b/src/strategies.ts
@@ -2,6 +2,7 @@ export const androidVesionStrategies = [
   'increment',
   'relative',
   'relative-extended',
+  'env',
   'none',
 ];
 
@@ -10,5 +11,6 @@ export const iosVesionStrategies = [
   'increment',
   'relative',
   'semantic',
+  'env',
   'none',
 ];

--- a/src/version/android.ts
+++ b/src/version/android.ts
@@ -28,6 +28,10 @@ const getNextAndroidVersionCode = (
     return currentVersionCode;
   }
 
+  if (strategy?.buildNumber === 'env') {
+    return process.env.ANDROID_BUILD_NUMBER;
+  }
+
   if (strategy?.buildNumber === 'relative') {
     const semanticBuildNumber = getSemanticBuildNumber(version, logger, 'Android');
 

--- a/src/version/android.ts
+++ b/src/version/android.ts
@@ -29,7 +29,15 @@ const getNextAndroidVersionCode = (
   }
 
   if (strategy?.buildNumber === 'env') {
-    return process.env.ANDROID_BUILD_NUMBER;
+    const envVersionCode = process.env.ANDROID_BUILD_NUMBER;
+    if (!envVersionCode) {
+      logger.warn(
+        'Could not update Android versionCode using the env strategy '
+        + 'as the ANDROID_BUILD_NUMBER could not be determined.',
+      );
+      return currentVersionCode;
+    }
+    return envVersionCode;
   }
 
   if (strategy?.buildNumber === 'relative') {

--- a/src/version/ios.ts
+++ b/src/version/ios.ts
@@ -88,7 +88,15 @@ const getIosBundleVersion = (
   }
 
   if (strategy?.buildNumber === 'env') {
-    return process.env.IOS_BUILD_NUMBER;
+    const envBundleVersion = process.env.IOS_BUILD_NUMBER;
+    if (!envBundleVersion) {
+      logger.warn(
+        'Could not update iOS bundle version using the env strategy '
+        + 'as the IOS_BUILD_NUMBER could not be determined.',
+      );
+      return currentBundleVersion;
+    }
+    return envBundleVersion;
   }
 
   if (strategy?.buildNumber === 'semantic') {

--- a/src/version/ios.ts
+++ b/src/version/ios.ts
@@ -87,6 +87,10 @@ const getIosBundleVersion = (
     return currentBundleVersion;
   }
 
+  if (strategy?.buildNumber === 'env') {
+    return process.env.IOS_BUILD_NUMBER;
+  }
+
   if (strategy?.buildNumber === 'semantic') {
     return stripPrereleaseVersion(version);
   }
@@ -386,6 +390,7 @@ export const versionIos = (
       || (
         buildNumber
         && buildNumber !== 'strict'
+        && buildNumber !== 'env'
       )
     )
   ) {

--- a/tests/prepare.test.ts
+++ b/tests/prepare.test.ts
@@ -429,6 +429,25 @@ describe('prepare', () => {
     });
   });
 
+  it('update versionCode using the env strategy', async () => {
+    const context = createContext();
+    process.env.ANDROID_BUILD_NUMBER = '123';
+
+    await prepare({
+      skipIos: true,
+      versionStrategy: {
+        android: {
+          buildNumber: 'env',
+        },
+      },
+    }, context);
+
+    expect(fs.writeFileSync).toHaveBeenCalledWith(defaultAndroidPath, [
+      'versionName "1.2.3"',
+      'versionCode 123',
+    ].join('\n'));
+  });
+
   describe('iOS', () => {
     beforeEach(() => {
       (fs.readdirSync as jest.Mock).mockImplementation((filePath) => {
@@ -1004,6 +1023,41 @@ describe('prepare', () => {
       expect(buildConfig.patch).toHaveBeenCalledWith({
         buildSettings: {
           CURRENT_PROJECT_VERSION: '1.1.1',
+        },
+      });
+    });
+
+    it('updates using the env versioning strategy', async () => {
+      const context = createContext({ version: '1.2.3' });
+
+      (plist.parse as jest.Mock).mockReturnValue({
+        CFBundleVersion: '1.1.1',
+      });
+      process.env.IOS_BUILD_NUMBER = '2.3.4';
+
+      getBuildSetting.mockImplementation((value: string) => ({
+        INFOPLIST_FILE: { text: 'Test/Info.plist' },
+        CURRENT_PROJECT_VERSION: { text: '1.1.1' },
+      }[value]));
+
+      await prepare({
+        skipAndroid: true,
+        versionStrategy: {
+          ios: {
+            buildNumber: 'env',
+          },
+        },
+      }, context);
+
+      expect(plist.build).toHaveBeenCalledTimes(1);
+      expect((plist.build as jest.Mock).mock.calls[0][0].CFBundleVersion).toBe(
+        '2.3.4',
+      );
+
+      expect(buildConfig.patch).toHaveBeenCalledTimes(1);
+      expect(buildConfig.patch).toHaveBeenCalledWith({
+        buildSettings: {
+          CURRENT_PROJECT_VERSION: '2.3.4',
         },
       });
     });

--- a/tests/prepare.test.ts
+++ b/tests/prepare.test.ts
@@ -446,6 +446,37 @@ describe('prepare', () => {
       'versionName "1.2.3"',
       'versionCode 123',
     ].join('\n'));
+   
+    delete process.env.ANDROID_BUILD_NUMBER;
+  });
+
+  it('do not update versionCode using the env strategy when variable not found', async () => {
+    const context = createContext();
+
+    (fs.readFileSync as jest.Mock).mockImplementation((filePath) => {
+      if (filePath.endsWith('build.gradle')) {
+        return [
+          'versionName "1.0.0"',
+          'versionCode 100',
+        ].join('\n');
+      }
+
+      return null;
+    });
+
+    await prepare({
+      skipIos: true,
+      versionStrategy: {
+        android: {
+          buildNumber: 'env',
+        },
+      },
+    }, context);
+
+    expect(fs.writeFileSync).toHaveBeenCalledWith(defaultAndroidPath, [
+      'versionName "1.2.3"',
+      'versionCode 100',
+    ].join('\n'));
   });
 
   describe('iOS', () => {
@@ -1058,6 +1089,42 @@ describe('prepare', () => {
       expect(buildConfig.patch).toHaveBeenCalledWith({
         buildSettings: {
           CURRENT_PROJECT_VERSION: '2.3.4',
+        },
+      });
+
+      delete process.env.IOS_BUILD_NUMBER;
+    });
+
+    it('does not update using the env versioning strategy when variable not found', async () => {
+      const context = createContext({ version: '1.2.3' });
+
+      (plist.parse as jest.Mock).mockReturnValue({
+        CFBundleVersion: '1.1.1',
+      });
+
+      getBuildSetting.mockImplementation((value: string) => ({
+        INFOPLIST_FILE: { text: 'Test/Info.plist' },
+        CURRENT_PROJECT_VERSION: { text: '1.1.1' },
+      }[value]));
+
+      await prepare({
+        skipAndroid: true,
+        versionStrategy: {
+          ios: {
+            buildNumber: 'env',
+          },
+        },
+      }, context);
+
+      expect(plist.build).toHaveBeenCalledTimes(1);
+      expect((plist.build as jest.Mock).mock.calls[0][0].CFBundleVersion).toBe(
+        '1.1.1',
+      );
+
+      expect(buildConfig.patch).toHaveBeenCalledTimes(1);
+      expect(buildConfig.patch).toHaveBeenCalledWith({
+        buildSettings: {
+          CURRENT_PROJECT_VERSION: '1.1.1',
         },
       });
     });

--- a/tests/prepare.test.ts
+++ b/tests/prepare.test.ts
@@ -446,7 +446,7 @@ describe('prepare', () => {
       'versionName "1.2.3"',
       'versionCode 123',
     ].join('\n'));
-   
+
     delete process.env.ANDROID_BUILD_NUMBER;
   });
 


### PR DESCRIPTION
This strategy allows us to handle build number calculation on the CI (increment it and keep it on CI variables) and replace it in files correctly.